### PR TITLE
Railgun grenade fix

### DIFF
--- a/src/main/java/pl/pabilo8/immersiveintelligence/common/IIRecipes.java
+++ b/src/main/java/pl/pabilo8/immersiveintelligence/common/IIRecipes.java
@@ -919,7 +919,7 @@ public class IIRecipes
 
 		AmmunitionWorkshopRecipe.addRecipe(
 				(core, casing) -> {
-					ItemStack stack = new ItemStack(IIContent.itemGrenade, 1, IIBlockTypes_Mine.MAIN.getMeta());
+					ItemStack stack = new ItemStack(IIContent.itemRailgunGrenade, 1, IIBlockTypes_Mine.MAIN.getMeta());
 					stack.deserializeNBT(core.serializeNBT());
 					return stack;
 				},

--- a/src/main/resources/assets/immersiveintelligence/lang/en_us.lang
+++ b/src/main/resources/assets/immersiveintelligence/lang/en_us.lang
@@ -1746,7 +1746,7 @@ ie.manual.entry.mortar1=In order to operate a Mortar, the artilleryman has to pl
 ie.manual.entry.grenades.name=Grenades
 ie.manual.entry.grenades.subtext=Achtung, Granate!
 ie.manual.entry.grenades0=The stick-hand-grenade is a thrown weapon that contains explosives or other material that triggers on contact. To assemble it, combine a treated stick with the appropriate grenade core in the <link;ammunition_assembler;§o§nAmmunition §o§nAssembler§r;>.
-ie.manual.entry.grenades1=Railgun grenades are ammunition for the Railgun and Heavy Railgun, which can be used instead of the standard metal rods. They can be filled with explosives or shrapnel and then be used as a portable artillery weapon. To assemble it, combine an aluminum rod with the appropriate grenade core in the <link;ammunition_assembler;§o§nAmmunition§o §nAssembler§r;>.
+ie.manual.entry.grenades1=Railgun grenades are ammunition for the Railgun and Heavy Railgun, which can be used instead of the standard metal rods. They can be filled with explosives or shrapnel and then be used as a portable artillery weapon. To assemble it, combine a steel rod with the appropriate grenade core in the <link;ammunition_assembler;§o§nAmmunition§o §nAssembler§r;>.
 
 #Reference to Rico, a penguin from the movie Madagascar
 ie.manual.entry.explosives_mines.name=Mines and Explosives


### PR DESCRIPTION
Railgun Grenades can be assembled in the workshop again, and the manual correctly states that they are made using steel rods, not aluminium